### PR TITLE
Raviole

### DIFF
--- a/services/surfaceflinger/Android.bp
+++ b/services/surfaceflinger/Android.bp
@@ -26,6 +26,7 @@ cc_defaults {
     defaults: [
         "surfaceflinger_defaults",
         "skia_renderengine_deps",
+        "surfaceflinger_qcom_ext_defaults",
     ],
     cflags: [
         "-DLOG_TAG=\"SurfaceFlinger\"",
@@ -91,7 +92,6 @@ cc_defaults {
         "android.hardware.graphics.composer@2.3-command-buffer",
         "android.hardware.graphics.composer@2.4-command-buffer",
         "android.hardware.graphics.composer3-command-buffer",
-        "display_intf_headers",
     ],
     export_static_lib_headers: [
         "libcompositionengine",

--- a/services/surfaceflinger/DisplayHardware/VirtualDisplaySurface.cpp
+++ b/services/surfaceflinger/DisplayHardware/VirtualDisplaySurface.cpp
@@ -326,8 +326,8 @@ status_t VirtualDisplaySurface::dequeueBuffer(Source source,
     if (source == SOURCE_SCRATCH) {
         usage |= GRALLOC_USAGE_HW_FB;
         usage &= ~(GRALLOC_USAGE_HW_VIDEO_ENCODER);
-        VDS_LOGV("dequeueBuffer(%s): updated scratch buffer usage flags=%#" PRIx64,
-                ftl::enum_string(source).c_str(), usage);
+        VDS_LOGV("%s(%s): updated scratch buffer usage flags=%#" PRIx64,
+                __func__, ftl::enum_string(source).c_str(), usage);
     }
 
     status_t result =

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -2921,7 +2921,8 @@ void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
         status = state.surface->query(NATIVE_WINDOW_FORMAT, &format);
         ALOGE_IF(status != NO_ERROR, "Unable to query format (%d)", status);
         pixelFormat = static_cast<ui::PixelFormat>(format);
-        if (mUseHwcVirtualDisplays) {
+        if (mVirtualDisplayIdGenerators.hal) {
+            size_t maxVirtualDisplaySize = getHwComposer().getMaxVirtualDisplayDimension();
             if (maxVirtualDisplaySize == 0 ||
                 ((uint64_t)resolution.width <= maxVirtualDisplaySize &&
                 (uint64_t)resolution.height <= maxVirtualDisplaySize)) {

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -808,6 +808,7 @@ void SurfaceFlinger::init() {
 
     mAllowHwcForWFD = base::GetBoolProperty("vendor.display.vds_allow_hwc"s, false);
     mAllowHwcForVDS = mAllowHwcForWFD && base::GetBoolProperty("debug.sf.enable_hwc_vds"s, false);
+    mFirstApiLevel = android::base::GetIntProperty("ro.product.first_api_level", 0);
 
     // Process any initial hotplug and resulting display changes.
     processDisplayHotplugEventsLocked();
@@ -6970,11 +6971,13 @@ bool SurfaceFlinger::canAllocateHwcDisplayIdForVDS(uint64_t usage) {
     // GRALLOC_USAGE_PRIVATE_WFD + GRALLOC_USAGE_HW_VIDEO_ENCODER = WFD using HW composer.
     flag_mask_pvt_wfd = GRALLOC_USAGE_PRIVATE_WFD;
     flag_mask_hw_video = GRALLOC_USAGE_HW_VIDEO_ENCODER;
+    bool isWfd = (usage & flag_mask_pvt_wfd) && (usage & flag_mask_hw_video);
     // Enabling only the vendor property would allow WFD to use HWC
     // Enabling both the aosp and vendor properties would allow all other VDS to use HWC
     // Disabling both would set all virtual displays to fall back to GPU
-    bool canAllocate = mAllowHwcForVDS || (mAllowHwcForWFD && (usage & flag_mask_pvt_wfd) &&
-                       (usage & flag_mask_hw_video));
+    // In vendor frozen targets, allow WFD to use HWC without any property settings.
+    bool canAllocate = mAllowHwcForVDS || (isWfd && mAllowHwcForWFD) || (isWfd &&
+                       mFirstApiLevel < __ANDROID_API_T__);
 
     if (canAllocate) {
         enableHalVirtualDisplays(true);

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -150,10 +150,12 @@
 #include <aidl/android/hardware/graphics/composer3/DisplayCapability.h>
 #include <aidl/android/hardware/graphics/composer3/RenderIntent.h>
 
+#ifdef QCOM_UM_FAMILY
 #if __has_include("QtiGralloc.h")
 #include "QtiGralloc.h"
 #else
 #include "gralloc_priv.h"
+#endif
 #endif
 
 #undef NO_THREAD_SAFETY_ANALYSIS
@@ -2905,7 +2907,11 @@ sp<DisplayDevice> SurfaceFlinger::setupNewDisplayDeviceInternal(
 
 void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
                                          const DisplayDeviceState& state) {
+#ifdef QCOM_UM_FAMILY
     bool canAllocateHwcForVDS = false;
+#else
+    bool canAllocateHwcForVDS = true;
+#endif
     ui::Size resolution(0, 0);
     ui::PixelFormat pixelFormat = static_cast<ui::PixelFormat>(PIXEL_FORMAT_UNKNOWN);
 
@@ -2921,6 +2927,7 @@ void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
         status = state.surface->query(NATIVE_WINDOW_FORMAT, &format);
         ALOGE_IF(status != NO_ERROR, "Unable to query format (%d)", status);
         pixelFormat = static_cast<ui::PixelFormat>(format);
+#ifdef QCOM_UM_FAMILY
         // Check if VDS is allowed to use HWC
         size_t maxVirtualDisplaySize = getHwComposer().getMaxVirtualDisplayDimension();
         if (maxVirtualDisplaySize == 0 || ((uint64_t)resolution.width <= maxVirtualDisplaySize &&
@@ -2933,6 +2940,7 @@ void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
                 canAllocateHwcForVDS = true;
             }
         }
+#endif
     } else {
         // Virtual displays without a surface are dormant:
         // they have external state (layer stack, projection,
@@ -6964,6 +6972,7 @@ status_t SurfaceFlinger::setDesiredDisplayModeSpecsInternal(
     return NO_ERROR;
 }
 
+#ifdef QCOM_UM_FAMILY
 bool SurfaceFlinger::canAllocateHwcDisplayIdForVDS(uint64_t usage) {
     uint64_t flag_mask_pvt_wfd = ~0;
     uint64_t flag_mask_hw_video = ~0;
@@ -6986,6 +6995,11 @@ bool SurfaceFlinger::canAllocateHwcDisplayIdForVDS(uint64_t usage) {
     return canAllocate;
 
 }
+#else
+bool SurfaceFlinger::canAllocateHwcDisplayIdForVDS(uint64_t) {
+    return true;
+}
+#endif
 
 status_t SurfaceFlinger::setDesiredDisplayModeSpecs(
         const sp<IBinder>& displayToken, ui::DisplayModeId defaultMode, bool allowGroupSwitching,

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -2921,8 +2921,7 @@ void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
         status = state.surface->query(NATIVE_WINDOW_FORMAT, &format);
         ALOGE_IF(status != NO_ERROR, "Unable to query format (%d)", status);
         pixelFormat = static_cast<ui::PixelFormat>(format);
-        if (mVirtualDisplayIdGenerators.hal) {
-            size_t maxVirtualDisplaySize = getHwComposer().getMaxVirtualDisplayDimension();
+        if (mUseHwcVirtualDisplays) {
             if (maxVirtualDisplaySize == 0 ||
                 ((uint64_t)resolution.width <= maxVirtualDisplaySize &&
                 (uint64_t)resolution.height <= maxVirtualDisplaySize)) {

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -806,9 +806,8 @@ void SurfaceFlinger::init() {
 
     enableLatchUnsignaledConfig = getLatchUnsignaledConfig();
 
-    if (base::GetBoolProperty("debug.sf.enable_hwc_vds"s, false)) {
-        enableHalVirtualDisplays(true);
-    }
+    mAllowHwcForWFD = base::GetBoolProperty("vendor.display.vds_allow_hwc"s, false);
+    mAllowHwcForVDS = mAllowHwcForWFD && base::GetBoolProperty("debug.sf.enable_hwc_vds"s, false);
 
     // Process any initial hotplug and resulting display changes.
     processDisplayHotplugEventsLocked();
@@ -2921,18 +2920,16 @@ void SurfaceFlinger::processDisplayAdded(const wp<IBinder>& displayToken,
         status = state.surface->query(NATIVE_WINDOW_FORMAT, &format);
         ALOGE_IF(status != NO_ERROR, "Unable to query format (%d)", status);
         pixelFormat = static_cast<ui::PixelFormat>(format);
-        if (mVirtualDisplayIdGenerators.hal) {
-            size_t maxVirtualDisplaySize = getHwComposer().getMaxVirtualDisplayDimension();
-            if (maxVirtualDisplaySize == 0 ||
-                ((uint64_t)resolution.width <= maxVirtualDisplaySize &&
-                (uint64_t)resolution.height <= maxVirtualDisplaySize)) {
-                uint64_t usage = 0;
-                // Replace with native_window_get_consumer_usage ?
-                status = state .surface->getConsumerUsage(&usage);
-                ALOGW_IF(status != NO_ERROR, "Unable to query usage (%d)", status);
-                if ((status == NO_ERROR) && canAllocateHwcDisplayIdForVDS(usage)) {
-                   canAllocateHwcForVDS = true;
-               }
+        // Check if VDS is allowed to use HWC
+        size_t maxVirtualDisplaySize = getHwComposer().getMaxVirtualDisplayDimension();
+        if (maxVirtualDisplaySize == 0 || ((uint64_t)resolution.width <= maxVirtualDisplaySize &&
+            (uint64_t)resolution.height <= maxVirtualDisplaySize)) {
+            uint64_t usage = 0;
+            // Replace with native_window_get_consumer_usage ?
+            status = state .surface->getConsumerUsage(&usage);
+            ALOGW_IF(status != NO_ERROR, "Unable to query usage (%d)", status);
+            if ((status == NO_ERROR) && canAllocateHwcDisplayIdForVDS(usage)) {
+                canAllocateHwcForVDS = true;
             }
         }
     } else {
@@ -6969,15 +6966,22 @@ status_t SurfaceFlinger::setDesiredDisplayModeSpecsInternal(
 bool SurfaceFlinger::canAllocateHwcDisplayIdForVDS(uint64_t usage) {
     uint64_t flag_mask_pvt_wfd = ~0;
     uint64_t flag_mask_hw_video = ~0;
-    char value[PROPERTY_VALUE_MAX] = {};
-    property_get("vendor.display.vds_allow_hwc", value, "0");
-    int allowHwcForVDS = atoi(value);
     // Reserve hardware acceleration for WFD use-case
     // GRALLOC_USAGE_PRIVATE_WFD + GRALLOC_USAGE_HW_VIDEO_ENCODER = WFD using HW composer.
     flag_mask_pvt_wfd = GRALLOC_USAGE_PRIVATE_WFD;
     flag_mask_hw_video = GRALLOC_USAGE_HW_VIDEO_ENCODER;
-    return (allowHwcForVDS || ((usage & flag_mask_pvt_wfd) &&
-            (usage & flag_mask_hw_video)));
+    // Enabling only the vendor property would allow WFD to use HWC
+    // Enabling both the aosp and vendor properties would allow all other VDS to use HWC
+    // Disabling both would set all virtual displays to fall back to GPU
+    bool canAllocate = mAllowHwcForVDS || (mAllowHwcForWFD && (usage & flag_mask_pvt_wfd) &&
+                       (usage & flag_mask_hw_video));
+
+    if (canAllocate) {
+        enableHalVirtualDisplays(true);
+    }
+
+    return canAllocate;
+
 }
 
 status_t SurfaceFlinger::setDesiredDisplayModeSpecs(

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1434,6 +1434,7 @@ private:
     FlagManager mFlagManager;
     bool mAllowHwcForVDS = false;
     bool mAllowHwcForWFD = false;
+    int mFirstApiLevel = 0;
 
     // returns the framerate of the layer with the given sequence ID
     float getLayerFramerate(nsecs_t now, int32_t id) const {

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -1432,6 +1432,8 @@ private:
     const sp<WindowInfosListenerInvoker> mWindowInfosListenerInvoker;
 
     FlagManager mFlagManager;
+    bool mAllowHwcForVDS = false;
+    bool mAllowHwcForWFD = false;
 
     // returns the framerate of the layer with the given sequence ID
     float getLayerFramerate(nsecs_t now, int32_t id) const {


### PR DESCRIPTION
resolves error below:
FAILED: /home/hurtcopain/zephyrus/out/soong/build.ninja
cd "$(dirname "/home/hurtcopain/zephyrus/out/host/linux-x86/bin/soong_build")" && BUILDER="$PWD/$(basename "/home/hurtcopain/zephyrus/out/host/linux-x86/bin/soong_build")" && cd / && env -i 
 "$BUILDER"     --top "$TOP"     --soong_out "/home/hurtcopain/zephyrus/out/soong"     --out "/home/hurtcopain/zephyrus/out"     -o /home/hurtcopain/zephyrus/out/soong/build.ninja --globList
Dir build --globFile /home/hurtcopain/zephyrus/out/soong/globs-build.ninja -t -l /home/hurtcopain/zephyrus/out/.module_paths/Android.bp.list --available_env /home/hurtcopain/zephyrus/out/soo
ng/soong.environment.available --used_env /home/hurtcopain/zephyrus/out/soong/soong.environment.used.build Android.bp
error: frameworks/native/services/surfaceflinger/fuzzer/Android.bp:91:1: "surfaceflinger_displayhardware_fuzzer" depends on undefined module "display_intf_headers"
Module "surfaceflinger_displayhardware_fuzzer" is defined in namespace "." which can read these 17 namespaces: ["." "." "hardware/google/graphics/common" "device/google/gs101" "hardware/goog
le/av" "hardware/google/graphics/gs101" "vendor/google_devices/raven" "hardware/google/interfaces" "hardware/google/pixel" "device/google/gs101/powerstats" "device/google/gs101/gnss/47765" "
device/google/gs101/conf" "device/google/gs-common/powerstats" "device/google/raviole" "hardware/google/gchips" "device/google/raviole/powerstats/raven" "hardware/google/gchips/gralloc4"]
Module "display_intf_headers" can be found in these namespaces: ["hardware/qcom-caf/msm8998" "hardware/qcom/display/msm8909" "hardware/qcom/sdm845" "vendor/qcom/opensource/commonsys-intf/dis
play"]
error: frameworks/native/services/surfaceflinger/Android.bp:246:1: "surfaceflinger" depends on undefined module "display_intf_headers"
Module "surfaceflinger" is defined in namespace "." which can read these 17 namespaces: ["." "." "hardware/google/graphics/common" "device/google/gs101" "hardware/google/av" "hardware/google
/graphics/gs101" "vendor/google_devices/raven" "hardware/google/interfaces" "hardware/google/pixel" "device/google/gs101/powerstats" "device/google/gs101/gnss/47765" "device/google/gs101/con
f" "device/google/gs-common/powerstats" "device/google/raviole" "hardware/google/gchips" "device/google/raviole/powerstats/raven" "hardware/google/gchips/gralloc4"]
Module "display_intf_headers" can be found in these namespaces: ["hardware/qcom-caf/msm8998" "hardware/qcom/display/msm8909" "hardware/qcom/sdm845" "vendor/qcom/opensource/commonsys-intf/dis
play"]
error: frameworks/native/services/surfaceflinger/fuzzer/Android.bp:105:1: "surfaceflinger_scheduler_fuzzer" depends on undefined module "display_intf_headers"
Module "surfaceflinger_scheduler_fuzzer" is defined in namespace "." which can read these 17 namespaces: ["." "." "hardware/google/graphics/common" "device/google/gs101" "hardware/google/av"
 "hardware/google/graphics/gs101" "vendor/google_devices/raven" "hardware/google/interfaces" "hardware/google/pixel" "device/google/gs101/powerstats" "device/google/gs101/gnss/47765" "device
/google/gs101/conf" "device/google/gs-common/powerstats" "device/google/raviole" "hardware/google/gchips" "device/google/raviole/powerstats/raven" "hardware/google/gchips/gralloc4"]
Module "display_intf_headers" can be found in these namespaces: ["hardware/qcom-caf/msm8998" "hardware/qcom/display/msm8909" "hardware/qcom/sdm845" "vendor/qcom/opensource/commonsys-intf/dis
play"]
error: frameworks/native/services/surfaceflinger/fuzzer/Android.bp:81:1: "surfaceflinger_fuzzer" depends on undefined module "display_intf_headers"
Module "surfaceflinger_fuzzer" is defined in namespace "." which can read these 17 namespaces: ["." "." "hardware/google/graphics/common" "device/google/gs101" "hardware/google/av" "hardware
/google/graphics/gs101" "vendor/google_devices/raven" "hardware/google/interfaces" "hardware/google/pixel" "device/google/gs101/powerstats" "device/google/gs101/gnss/47765" "device/google/gs
101/conf" "device/google/gs-common/powerstats" "device/google/raviole" "hardware/google/gchips" "device/google/raviole/powerstats/raven" "hardware/google/gchips/gralloc4"]
Module "display_intf_headers" can be found in these namespaces: ["hardware/qcom-caf/msm8998" "hardware/qcom/display/msm8909" "hardware/qcom/sdm845" "vendor/qcom/opensource/commonsys-intf/dis
play"]
error: frameworks/native/services/surfaceflinger/fuzzer/Android.bp:115:1: "surfaceflinger_layer_fuzzer" depends on undefined module "display_intf_headers"
Module "surfaceflinger_layer_fuzzer" is defined in namespace "." which can read these 17 namespaces: ["." "." "hardware/google/graphics/common" "device/google/gs101" "hardware/google/av" "ha
rdware/google/graphics/gs101" "vendor/google_devices/raven" "hardware/google/interfaces" "hardware/google/pixel" "device/google/gs101/powerstats" "device/google/gs101/gnss/47765" "device/goo
gle/gs101/conf" "device/google/gs-common/powerstats" "device/google/raviole" "hardware/google/gchips" "device/google/raviole/powerstats/raven" "hardware/google/gchips/gralloc4"]
Module "display_intf_headers" can be found in these namespaces: ["hardware/qcom-caf/msm8998" "hardware/qcom/display/msm8909" "hardware/qcom/sdm845" "vendor/qcom/opensource/commonsys-intf/dis
play"]
